### PR TITLE
Fix README command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Personal web page with jekyll
 gem update
 gem install bundler
 bundle update
-bundle exec jekyll server
+bundle exec jekyll serve
 ```
 
 ```sh   


### PR DESCRIPTION
## Summary
- correct the jekyll command in README

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f7843b9788327b414cb7ef272f299