### PR TITLE
Fix broken links in categories page

### DIFF
--- a/categories.md
+++ b/categories.md
@@ -10,7 +10,7 @@ permalink: /categories/
 {% assign sorted_posts = site.categories[category_name]  | sort: date | reverse %}
 {% for post in sorted_posts %}
 **[{{ post.title }}]({{ post.url }})**      
-<small>{% if post.github %}[GitHub](post.github) | {% endif %}{% if post.medium %}[Medium](post.medium) | {% endif %}{{ post.date | date: "%d %B %Y" }}{% if post.categories %}<i>{% for category in post.categories %} | {{ category }} {% endfor %}</i>{% endif %}</small>  
+<small>{% if post.github %}[GitHub]({{ post.github }}) | {% endif %}{% if post.medium %}[Medium]({{ post.medium }}) | {% endif %}{{ post.date | date: "%d %B %Y" }}{% if post.categories %}<i>{% for category in post.categories %} | {{ category }} {% endfor %}</i>{% endif %}</small>
 {{ post.summary }}
 
 {% endfor %}


### PR DESCRIPTION
## Summary
- fix GitHub/Medium link syntax on `categories.md`
- ensure newline at EOF

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f76dec0c883278a5c3be192ffed2b